### PR TITLE
Protect against FilerException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>cucumber-annotation-indexer</artifactId>
-  <version>1.3-SNAPSHOT</version>
+  <version>1.2-Ericsson.1</version>
 
   <name>Cucumber Annotation Indexer</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
 
   <artifactId>cucumber-annotation-indexer</artifactId>
-  <version>1.2-Ericsson.1</version>
+  <version>1.3-SNAPSHOT</version>
 
   <name>Cucumber Annotation Indexer</name>
 

--- a/src/main/java/org/kohsuke/cukes/CukeAnnotationIndexer.java
+++ b/src/main/java/org/kohsuke/cukes/CukeAnnotationIndexer.java
@@ -7,6 +7,7 @@ import cucumber.runtime.java.StepDefAnnotation;
 import org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl;
 import org.kohsuke.MetaInfServices;
 
+import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -62,6 +63,9 @@ public class CukeAnnotationIndexer extends AnnotationProcessorImpl {
                 }
             } catch (FileNotFoundException x) {
                 // this file is created for the first time
+            } catch (FilerException x) {
+                processingEnv.getMessager().printMessage(Kind.WARNING, x.toString());
+                return;
             }
 
             FileObject out = processingEnv.getFiler().createResource(CLASS_OUTPUT,


### PR DESCRIPTION
If an annotation processor is called more than once, you may receive a FilerException.
This protects against that case.
